### PR TITLE
(DOC) Partners do not need a Jira account

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ CONTRIBUTING.md document.
 
 Anyone who wants to contribute needs a [GitHub account](https://github.com/signup/free)
 
-Puppet employees and partner need a [Jira account](https://tickets.puppetlabs.com)
-to create and track tickets.
+Puppet employees need a [Jira account](https://tickets.puppetlabs.com) to create
+and track tickets.
 
 Create a new fork of the repository within your own GitHub user namespace.
 


### PR DESCRIPTION
Partners do not need a Jira account to make changes. Removed the reference to this requirement.