### PR TITLE
Fix the trivial patch exemption policy URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ CONTRIBUTING.md document.
 External contributors making significant contributions to our projects must sign the
 [Contributor License Agreement](https://cla.puppet.com).
 
-For [trivial changes](https://docs.puppet.com/community/trivial_patch_exemption.html),
+For [trivial changes](https://puppet.com/community/trivial-patch-exemption-policy),
 no signature is required.
 
 ## Workflow


### PR DESCRIPTION
The current URL (https://docs.puppet.com/community/trivial_patch_exemption.html) for trivial changes returns 404, replaced with a working one (https://puppet.com/community/trivial-patch-exemption-policy).

Hope you're having a great day! :)